### PR TITLE
upgraded absl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,9 +36,8 @@ http_archive(
     urls = ["https://github.com/grpc/grpc/archive/refs/tags/v1.54.0.tar.gz"],
 )
 
-ABSL_COMMIT = "273292d1cfc0a94a65082ee350509af1d113344d"
-
-ABSL_SHA256 = "94aef187f688665dc299d09286bfa0d22c4ecb86a80b156dff6aabadc5a5c26d"
+ABSL_COMMIT = "fb3621f4f897824c0dbe0615fa94543df6192f30"
+ABSL_SHA256 = "0320586856674d16b0b7a4d4afb22151bdc798490bb7f295eddd8f6a62b46fea"
 
 http_archive(
     name = "com_google_absl",

--- a/oss_build.sh
+++ b/oss_build.sh
@@ -27,6 +27,8 @@ set -o pipefail
 
 # Flags
 PYTHON_VERSIONS=3.9 # Options 3.7 (default), 3.8, or 3.9.
+# CLEAN=true # Set to true to run bazel clean.
+# CLEAR_CACHE=true # Set to true to delete Bazel cache folder. b/279235134
 CLEAN=false # Set to true to run bazel clean.
 CLEAR_CACHE=false # Set to true to delete Bazel cache folder. b/279235134
 OUTPUT_DIR=/tmp/reverb/dist/

--- a/reverb/cc/support/tf_util.h
+++ b/reverb/cc/support/tf_util.h
@@ -24,26 +24,12 @@ namespace reverb {
 
 // Converts a tensorflow::Status object to an absl::Status object.
 inline absl::Status FromTensorflowStatus(const tensorflow::Status& status) {
-  if (status.ok()) {
-    return absl::Status();
-  } else {
-    // TODO: This could be wrong? It looks like message does not exist for TF status?
-    return absl::Status(static_cast<absl::StatusCode>(status.code()),
-                        status.error_message());
-  }
+  return status;
 }
 
 // Converts an absl::Status object to a tensorflow::Status object.
 inline tensorflow::Status ToTensorflowStatus(const absl::Status& status) {
-  if (status.ok()) {
-    return tensorflow::Status();
-  } else {
-    // TODO: Could very well be wrong?
-    // TODO: Maybe constructor linked below did not exist in version of TF I am using?
-    // TODO: https://github.com/tensorflow/tensorflow/blob/cb16f493dcf46f502296a76b23d40c813a2b4b2f/tensorflow/tsl/platform/status.h#L105
-    // return tensorflow::Status(status.code(), status.message());
-    return tensorflow::Status(static_cast<tsl::error::Code>(status.code()), status.message());
-  }
+  return status;
 }
 
 }  // namespace reverb


### PR DESCRIPTION
Addressing problems with macOS Sonoma deprecations in absl by bumping the absl version. This requires a version bump in TensorFlow as well to v2.16.1 since we need to keep the absl used by reverb and TensorFlow the same. There's small changes in reverb to address absl & TensorFlow version changes